### PR TITLE
Remove embedded AWS provider from this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ module "container_service" {
 - `lb_container_port` - Port the ALB will route traffic to on the container (Default: `unknown`)
 - `custom_url` - Prefix for the URL - environment will append. I.e. test will be test-env.whatever.com (Default `unknown`)
 - `service_desired_count` - Number of services desired to run - Ignored after initial run (Default: `1`)
-- `region` - Where it all happens (Default: `us-east-1`)
 - `mem_threshold_up` - Percentage of MEM utilization to trigger scaling up action (Default: `60`)
 - `mem_up_evaluation_periods` - How many periods of alarm until scaling up is triggered (Default: `3`)
 - `mem_up_time_period` - How much time is one period (Default: `60`)

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  region     = "${var.region}"
-  profile    = "${var.profile}"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,3 @@
-variable "profile" {
-  default = "default"
-}
 variable "vpc_id" {}
 variable "task_definition" {}
 variable "target_group_arn" {}
@@ -11,7 +8,7 @@ variable "cluster_name" {
   default = "dev-cluster"
 }
 variable "public_subnet_ids" {
-  type    = "list"
+  type = "list"
 }
 variable "private_subnet_ids" {
   type = "list"
@@ -27,9 +24,6 @@ variable "environment" {
 }
 variable "service_desired_count" {
   default = 3
-}
-variable "region" {
-  default = "us-west-2"
 }
 variable "mem_threshold_up" {
   default = 60


### PR DESCRIPTION
# Purpose
Fix the profile issues that are caused by this embedded provider

# Implementation
Remove the embedded provider block.

# Notes
I'd merge this, tag as `2.3.1` and then bump the stacks that reference this module to use `2.3.1` in our audit fixes branch.

# Reviewers
@shawncatz @kiamatt 