### PR TITLE
Enable tag propagation

### DIFF
--- a/service.tf
+++ b/service.tf
@@ -25,4 +25,6 @@ resource "aws_ecs_service" "main" {
   deployment_controller {
     type = var.deployment_type
   }
+
+  propagate_tags = "SERVICE"
 }


### PR DESCRIPTION
# Purpose
Ensure we can track our ECS service spend by Stack tag for our legacy ECS services.

# Implementation
Enable tag propagation.

# Reviewers
@shawncatz 