### PR TITLE
Ignore task def changes for code_deploy services

### DIFF
--- a/cpu_as.tf
+++ b/cpu_as.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
 
   dimensions = {
     ClusterName = "${var.cluster_name}"
-    ServiceName = "${aws_ecs_service.main.name}"
+    ServiceName = "${local.service_resource.name}"
   }
 
   alarm_actions = concat([aws_appautoscaling_policy.cpu_up.arn], var.additional_scale_alarm_actions)
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
 
   dimensions = {
     ClusterName = "${var.cluster_name}"
-    ServiceName = "${aws_ecs_service.main.name}"
+    ServiceName = "${local.service_resource.name}"
   }
 
   alarm_actions = concat([aws_appautoscaling_policy.cpu_down.arn], var.additional_scale_alarm_actions)
@@ -38,14 +38,14 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
 
 resource "aws_appautoscaling_target" "scale_target" {
   service_namespace  = "ecs"
-  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
+  resource_id        = "service/${var.cluster_name}/${local.service_resource.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   role_arn           = var.service_role_arn
   min_capacity       = var.service_asg_min_cap
   max_capacity       = var.service_asg_max_cap
 
   depends_on = [
-    aws_ecs_service.main
+    local.service_resource
   ]
 
 }
@@ -53,7 +53,7 @@ resource "aws_appautoscaling_target" "scale_target" {
 resource "aws_appautoscaling_policy" "cpu_up" {
   name               = "${var.project}-${var.environment}-scale-up"
   service_namespace  = "ecs"
-  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
+  resource_id        = "service/${var.cluster_name}/${local.service_resource.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
@@ -72,7 +72,7 @@ resource "aws_appautoscaling_policy" "cpu_up" {
 resource "aws_appautoscaling_policy" "cpu_down" {
   name               = "${var.project}-${var.environment}-scale-down"
   service_namespace  = "ecs"
-  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
+  resource_id        = "service/${var.cluster_name}/${local.service_resource.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "name" {
-  value = aws_ecs_service.main.name
+  value = local.service_resource.name
 }

--- a/service.tf
+++ b/service.tf
@@ -1,6 +1,5 @@
-moved {
-  from = aws_ecs_service.main
-  to   = aws_ecs_service.default[0]
+locals {
+  service_resource = var.deployment_type != "CODE_DEPLOY" ? aws_ecs_service.default[0] : aws_ecs_service.code_deploy[0]
 }
 
 # The only difference between aws_ecs_service.default and aws_ecs_service.code_deploy are the lifecycle blocks.

--- a/service.tf
+++ b/service.tf
@@ -1,4 +1,12 @@
-resource "aws_ecs_service" "main" {
+moved {
+  from = aws_ecs_service.main
+  to   = aws_ecs_service.default[0]
+}
+
+# The only difference between aws_ecs_service.default and aws_ecs_service.code_deploy are the lifecycle blocks.
+# The aws_ecs_service.code_deploy block ignores changes to the task definition, which is updated by CodeDeploy.
+resource "aws_ecs_service" "default" {
+  count           = var.deployment_type != "CODE_DEPLOY" ? 1 : 0
   name            = var.project
   cluster         = var.cluster_name
   task_definition = var.task_definition
@@ -20,6 +28,38 @@ resource "aws_ecs_service" "main" {
 
   lifecycle {
     ignore_changes = [load_balancer, desired_count]
+  }
+
+  deployment_controller {
+    type = var.deployment_type
+  }
+
+  propagate_tags = "SERVICE"
+}
+
+resource "aws_ecs_service" "code_deploy" {
+  count           = var.deployment_type == "CODE_DEPLOY" ? 1 : 0
+  name            = var.project
+  cluster         = var.cluster_name
+  task_definition = var.task_definition
+  desired_count   = var.service_desired_count
+  launch_type     = "FARGATE"
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = var.container_security_groups
+    assign_public_ip = var.assign_public_ip
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = var.lb_container_name
+    container_port   = var.lb_container_port
+  }
+
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
+
+  lifecycle {
+    ignore_changes = [load_balancer, desired_count, task_definition]
   }
 
   deployment_controller {


### PR DESCRIPTION
# Purpose
Fix drift for legacy/ecs/service/{jetty_api,jetty_job}. These services are deployed via code_deploy, so we shouldn't be trying to manage the task_definition version.

# Implementation
Duplicate the `aws_ecs_service` resource into `default`, used by default, and `code_deploy`, used when deployment_type is `CODE_DEPLOY`. On the latter, add a lifecycle_ignore for the task_definition.

# Notes
Once this lands and I tag it, I'll update our downstream services in guru-ops with the `moved` blocks needed to make this change transparent.

# Notifications
@shawncatz 